### PR TITLE
A few fixes in the build process

### DIFF
--- a/templates/x86_64/fs/home/user/.profile
+++ b/templates/x86_64/fs/home/user/.profile
@@ -1,0 +1,7 @@
+if [ $(id -u) == 0 ]; then
+    COLOR="31"
+else
+    COLOR="34"
+    cd /home/user
+fi
+export PS1="\e[01;${COLOR}m$(whoami)@slub-vm\[\033[00m\]:\[\033[36m\]\w\[\033[00m\]\$ "

--- a/templates/x86_64/start.sh
+++ b/templates/x86_64/start.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# Create mount point if needed
+mkdir -p mountpoint/
+
+# Running QEMU
 qemu-system-x86_64 \
     -kernel ./bzImage \
     -initrd ./initramfs.cpio.gz  \


### PR DESCRIPTION
I noticed a few bugs after completing the build process, mainly:

- The `mountpoint/` directory was not created.

  I added a line that create it in the main `Makefile`.  The drawback is that some vm may not have `mountpoint/`.  But, in some way, they should always have one...

- The empty path `/home/user/` has been omitted by git as it is an empty directory (no file).

  I added a `/home/user/.profile` file (taken from `/etc/profile`) to force `git` to keep track of this path. The drawback is that an empty `/home/user` is surely better for what we need...

Feel free to comment on my fixes and propose some improvement if needed.

EDIT
----------------------------

I added a commit allowing to build multi-architecture VM. A few things about it:

- I am not sure that the `export` in `linux/Makefile` and `busybox/Makefile` are really necessary.
- I struggled a lot before noticing that `linux/build/arch/<ARCH>/boot/bzImage` was not a standard. In fact, it seems that each architecture has its own name for the image. For AArch64, the name is `Image.gz`. So, I added a shell variable that gives the name of the Image. But, it seems that, at the end, the `Image.gz` is copied to `build/vm` with the name `bzImage` finally. I do not know if we want change this.

Finally, note that the final vm in AArch64 is not working because the QEMU options are not right (but the build process goes fine all along). So, there is still work left!