### PR TITLE
Small patch

### DIFF
--- a/templates/x86_64/Makefile.inc
+++ b/templates/x86_64/Makefile.inc
@@ -11,16 +11,16 @@ export CONF_BUSYBOX_ARCH=x86_64
 export CONF_CROSS_COMPILE_PREFIX=
 
 # Name of the Linux TAR archive
-export CONF_LINUX_ARCHIVE=linux-4.18.16.tar.xz
+export CONF_LINUX_ARCHIVE=linux-5.8.9.tar.xz
 
 # URL of Linux archive
-export CONF_LINUX_URL=https://cdn.kernel.org/pub/linux/kernel/v4.x/$(CONF_LINUX_ARCHIVE)
+export CONF_LINUX_URL=https://cdn.kernel.org/pub/linux/kernel/v5.x/$(CONF_LINUX_ARCHIVE)
 
 # Name of the Busybox TAR archive
-export CONF_BUSYBOX_ARCHIVE=busybox-1.29.3.tar.bz2
+export CONF_BUSYBOX_ARCHIVE=busybox-1.32.0.tar.bz2
 
 # URL of Busybox archive
 export CONF_BUSYBOX_URL=https://busybox.net/downloads/$(CONF_BUSYBOX_ARCHIVE)
 
 # Number of CPUs for compilation
-export CONF_CPUS=3
+export CONF_CPUS=4


### PR DESCRIPTION
5.8.9 kernel

1.32 busybox version because of the 1.29 version seems buggy.